### PR TITLE
addtask updated

### DIFF
--- a/lib/features/task/data/repositories/task_repository.dart
+++ b/lib/features/task/data/repositories/task_repository.dart
@@ -14,16 +14,20 @@ class TaskRepository implements TaskRepositoryContract {
   TaskRepository({required this.localDataSource});
 
   @override
-  Future<Either<Failure, AddSuccess>> addTask(String name) async {
+  Future<Either<Failure, TodoTask>> addTask(String name) async {
     try {
       String id = uuid.v1();
-      TodoTaskModel tempTaskModel = TodoTaskModel(
+      TodoTaskModel newTask = TodoTaskModel(
         id: id,
         name: name,
         isDone: false,
       );
-      await localDataSource.addTaskToLocal(tempTaskModel);
-      return Right(AddSuccess());
+      await localDataSource.addTaskToLocal(newTask);
+      return Right(TodoTask(
+        id: newTask.id,
+        name: newTask.name,
+        isDone: newTask.isDone,
+      ));
     } catch (e) {
       return Left(CacheFailure());
     }

--- a/lib/features/task/domain/repository_contracts/task_repository_contract.dart
+++ b/lib/features/task/domain/repository_contracts/task_repository_contract.dart
@@ -5,7 +5,7 @@ import 'package:todoey/features/task/domain/entities/task.dart';
 
 abstract class TaskRepositoryContract {
   Future<Either<Failure, List<TodoTask>>> getTaskList();
-  Future<Either<Failure, AddSuccess>> addTask(String name);
+  Future<Either<Failure, TodoTask>> addTask(String name);
   Future<Either<Failure, DeleteSuccess>> deleteTask(String taskId);
   Future<Either<Failure, UpdateSuccess>> updateTask(TodoTask task);
 }

--- a/lib/features/task/domain/usecases/add_task.dart
+++ b/lib/features/task/domain/usecases/add_task.dart
@@ -1,15 +1,15 @@
 import 'package:todoey/core/error/failures.dart';
 import 'package:dartz/dartz.dart';
-import 'package:todoey/core/success/success.dart';
 import 'package:todoey/core/usecase/usecase.dart';
+import 'package:todoey/features/task/domain/entities/task.dart';
 import 'package:todoey/features/task/domain/repository_contracts/task_repository_contract.dart';
 
-class AddTask extends UseCase<AddSuccess, AddTaskParams> {
+class AddTask extends UseCase<TodoTask, AddTaskParams> {
   final TaskRepositoryContract repository;
   AddTask(this.repository);
 
   @override
-  Future<Either<Failure, AddSuccess>> call(params) async {
+  Future<Either<Failure, TodoTask>> call(params) async {
     return await repository.addTask(params.name);
   }
 }


### PR DESCRIPTION
yeni task eklerken sadece ismini gönderiyoruz. data layerda id generate ediliyor yeni bir task entity oluşturuluyor ve dosyaya yazılıyor. presentation tarafında bu yeni oluşturulan entity'İ state eklemek için geriye yeni oluştural TodoTask döndürülmesi daha mantıklı geldi. diğer türlü tüm listeyi yeniden almak gerekirdi.